### PR TITLE
Add quick and dirty script to extract metadata to JSON

### DIFF
--- a/scripts/extract_metadata.py
+++ b/scripts/extract_metadata.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from pprint import pprint
+
+from yaml import load, load_all, dump
+
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+import json
+
+from pathlib import Path
+
+content_dir = Path("./content")
+content_files = content_dir.glob("*.md")
+
+metadata = []
+for filename in content_files:
+    with open(filename) as f:
+        docs = load_all(f, Loader=Loader)
+        record = next(docs)
+        record["filename"] = str(filename)
+        if "type" in record:
+            metadata.append(record)
+
+with open("metadata.json", "w") as output:
+    json.dump(metadata, output)


### PR DESCRIPTION
This will extract the YAML frontmatter from files under `content`, filter down to just the relevant records and dump the result to JSON for further bulk updates.